### PR TITLE
Fixing wrong variable name

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/css/css-in-js.md
+++ b/microsoft-edge/devtools-guide-chromium/css/css-in-js.md
@@ -107,8 +107,8 @@ You can create a completely new stylesheet as well:
 ```javascript
 // Create a completely new stylesheet
 const sheet = new CSSStyleSheet();
-stylesheet.replaceSync('.some { color: blue; }');
-stylesheet.insertRule('.some { color: green; }');
+sheet.replaceSync('.some { color: blue; }');
+sheet.insertRule('.some { color: green; }');
 ```
 
 ```javascript


### PR DESCRIPTION
`sheet` is the newly defined stylesheet variable.
The functions `replaceSync()` and `insertRule` cannot be called from a variable that doesn't exist.